### PR TITLE
Update native libs and fix gesture lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,11 +72,8 @@ artifacts/
 
 # Samples.
 #
-# The samples live in the Pysar.Samples repository and are not duplicated here. Pysar.Dev.sln is
-# Pysar.sln plus those projects, reached as ..\Pysar.Samples\src\ - it only opens where that
-# repository is checked out next to this one, so it stays local rather than tracked. samples/ is
-# ignored as well: earlier layouts kept a copy or a symbolic link there, and neither belongs in
-# this repository now.
+# Pysar.Dev.sln and samples/ (symlinks into Pysar.Samples) stay local. They must not be
+# committed: git would follow the links and publish Samples sources into this repository.
 Pysar.Dev.sln
 Pysar.Dev.slnf
 samples/

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <!-- Central Package Management: all package versions defined here. -->
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Avalonia UI framework -->
     <PackageVersion Include="Avalonia" Version="12.1.1" />
@@ -17,55 +17,55 @@
     <PackageVersion Include="Avalonia.Skia" Version="12.1.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
-
     <!-- MAUI -->
-    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.90" />
-
+    <PackageVersion Include="Microsoft.Maui.Controls" Version="10.0.100" />
     <!-- Roslyn / Code Analysis -->
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
-
     <!-- Dependency Injection & Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.14" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.11" />
-
     <!-- Blazor WebAssembly -->
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.11" />
-
     <!-- Testing (used in src, tests, and plugins) -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
-
     <!-- SkiaSharp & Vector Graphics -->
-    <PackageVersion Include="SkiaSharp" Version="4.151.1" />
+    <PackageVersion Include="SkiaSharp" Version="4.151.2" />
     <!-- The main SkiaSharp package only bundles win-x64/win-x86 and osx native binaries, but
          leaving that implicit lets a transitive dependency on an older SkiaSharp line (SkiaSharp.QrCode
-         1.1.1 wants 4.148.0) resolve its own Win32/macOS native assets unpinned, so two incompatible
+         wants 4.148.0) resolve its own Win32/macOS native assets unpinned, so two incompatible
          copies of libSkiaSharp end up in the same output and whichever copies last wins - the native
-         library then reports an internal engine version the 4.151.1 managed wrapper rejects at
+         library then reports an internal engine version the 4.151.2 managed wrapper rejects at
          startup ("SkiaSharpVersion.CheckNativeLibraryCompatible" throws). Pinning these here, exactly
          like the platforms below that always needed it explicitly, forces one consistent version.
     -->
-    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Android" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.MacCatalyst" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="4.151.1" />
-    <PackageVersion Include="SkiaSharp.QrCode" Version="1.1.1" />
-    <PackageVersion Include="Svg.Skia" Version="5.2.0" />
-
+    <PackageVersion Include="SkiaSharp.NativeAssets.Win32" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.macOS" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Android" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.iOS" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.MacCatalyst" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.WebAssembly" Version="4.151.2" />
+    <PackageVersion Include="SkiaSharp.QrCode" Version="1.2.0" />
+    <PackageVersion Include="HarfBuzzSharp" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Win32" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.macOS" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Linux" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.Android" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.iOS" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.MacCatalyst" Version="14.2.0" />
+    <PackageVersion Include="HarfBuzzSharp.NativeAssets.WebAssembly" Version="14.2.0" />
+    <PackageVersion Include="Svg.Skia" Version="5.2.3" />
     <!-- JetBrains Rider SDK -->
     <PackageVersion Include="JetBrains.Rider.SDK" Version="2026.1.1" />
     <PackageVersion Include="Wave" Version="261.0.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
-
     <!-- Misc -->
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="System.Text.Json" Version="8.0.5" />

--- a/src/Pysar.Maui/Pysar.Maui.csproj
+++ b/src/Pysar.Maui/Pysar.Maui.csproj
@@ -46,7 +46,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Maui.Controls" />
         <!--
-          Align native libSkiaSharp with managed SkiaSharp from Pysar.Skia (4.151.1).
+          Align native libSkiaSharp with managed SkiaSharp from Pysar.Skia (4.151.2).
           Without this, a stale 3.119 framework can remain in the app bundle after upgrades and
           crash at startup: native 119.0 is outside the supported [151.0, 152.0) range.
         -->
@@ -54,14 +54,17 @@
     </ItemGroup>
     <ItemGroup Condition="$(TargetFramework.Contains('maccatalyst'))">
         <PackageReference Include="SkiaSharp.NativeAssets.MacCatalyst" />
+        <PackageReference Include="HarfBuzzSharp.NativeAssets.MacCatalyst" />
         <LinkerArg Include="-framework" />
         <LinkerArg Include="AppKit" />
     </ItemGroup>
     <ItemGroup Condition="$(TargetFramework.Contains('-ios'))">
         <PackageReference Include="SkiaSharp.NativeAssets.iOS" />
+        <PackageReference Include="HarfBuzzSharp.NativeAssets.iOS" />
     </ItemGroup>
     <ItemGroup Condition="$(TargetFramework.Contains('android'))">
         <PackageReference Include="SkiaSharp.NativeAssets.Android" />
+        <PackageReference Include="HarfBuzzSharp.NativeAssets.Android" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pysar.Maui/ReportView.cs
+++ b/src/Pysar.Maui/ReportView.cs
@@ -186,6 +186,7 @@ public partial class ReportView : ContentView, IReportViewHost, IReportViewSurfa
             if (Handler is null)
             {
                 DeviceDisplay.Current.MainDisplayInfoChanged -= OnDisplayChanged;
+                RemovePlatformGestures();
                 _reportSession.DisposeWhenStillDetached(() => Handler is not null);
 
                 return;
@@ -198,6 +199,7 @@ public partial class ReportView : ContentView, IReportViewHost, IReportViewSurfa
             DeviceDisplay.Current.MainDisplayInfoChanged += OnDisplayChanged;
 
             RefreshDensity();
+            AddPlatformGestures();
 
             // Shell flyout navigation disconnects the handler for more than one turn, so the
             // deferred dispose above actually runs. Coming back does not change Report, and

--- a/src/Pysar.Maui/ReportViewGestures.Apple.cs
+++ b/src/Pysar.Maui/ReportViewGestures.Apple.cs
@@ -32,8 +32,12 @@ public partial class ReportView
         // Against the view rather than against the recogniser: after Shell flyout navigation the
         // handler comes back with a new UIScrollView, and a recogniser still held from the previous
         // one is attached to a view nobody's fingers can reach - which is what left a report reopened
-        // from the flyout no longer zooming.
-        if (ReferenceEquals(_platformPinchView, view))
+        // from the flyout no longer zooming. The same UIView can also come back with UIKit having
+        // stripped the recogniser, so identity alone is not enough to skip.
+        if (ReferenceEquals(_platformPinchView, view)
+            && _platformPinch is not null
+            && view.GestureRecognizers is { } recognizers
+            && Array.IndexOf(recognizers, _platformPinch) >= 0)
             return;
 
         RemovePlatformGestures();

--- a/src/Pysar.Maui/ReportViewGestures.cs
+++ b/src/Pysar.Maui/ReportViewGestures.cs
@@ -57,6 +57,11 @@ public partial class ReportView
         };
 
         _scroll.HandlerChanged += (_, _) => AddPlatformGestures();
+
+        // HandlerChanged on the scroll view is not enough: Shell can reconnect this control
+        // without replacing the scroll handler, and UIKit may have stripped the recogniser
+        // from a reused UIScrollView. Loaded is the point the native view is in a window.
+        Loaded += (_, _) => AddPlatformGestures();
     }
 
     /// <summary>


### PR DESCRIPTION
Enable central transitive pinning and bump package versions to align native libraries: Microsoft.Maui.Controls, Microsoft.Extensions, SkiaSharp (4.151.2) and native assets, Svg.Skia, SkiaSharp.QrCode, and add HarfBuzzSharp + its native assets. Add HarfBuzz native package refs to the MAUI csproj. Fix ReportView gesture lifecycle by adding AddPlatformGestures/RemovePlatformGestures calls, register Loaded to reattach gestures, and strengthen the Apple recognizer identity check. Also clarify .gitignore wording for local samples/ and dev solution.